### PR TITLE
Tor Exit IP list moved and $(...) notation

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -7,8 +7,8 @@ torOutputFile="tor-redirect.js";
 ProductionDir="/var/www/website/path/here/";
 
 # GET INFO FROM TORPROJECT.ORG
-torLastUpdate=`curl --silent https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1 |grep 'This file was generated on' |sed 's/\# This file was generated on //g;s/ \#//g'`;
-torExitIPList=`curl --silent https://check.torproject.org/cgi-bin/TorBulkExitList.py?ip=1.1.1.1 |grep -v "#" |sort -u |awk '{print "\"" $1 "\","}' |tr -d "\n" |sed 's/.$//'`;
+torLastUpdate=$(curl --silent https://check.torproject.org/torbulkexitlist?ip=1.1.1.1 | grep 'This file was generated on' | sed 's/\# This file was generated on //g;s/ \#//g')
+torExitIPList=$(curl --silent https://check.torproject.org/torbulkexitlist?ip=1.1.1.1 | grep -v "#" | sort -u | awk '{print "\"" $1 "\","}' | tr -d "\n" | sed 's/.$//')
 
 # COMPILE OUTPUT FILE
 sed 's/\#DATE\#/'"$torLastUpdate"'/g;s/\#ARRAY-OF-TOR-IPS\#/'"$torExitIPList"'/g' $torWorkingDir$torSourceFile > $torWorkingDir$torOutputFile;


### PR DESCRIPTION
The Tor Exit IP list has moved.
Use $(...) notation instead of backticked `...`