### PR TITLE
sorting with -n parameter

### DIFF
--- a/generator.sh
+++ b/generator.sh
@@ -10,7 +10,7 @@ ProductionDir="/var/www/website/path/here/";
 torLastUpdate=$(date -u)
 
 # GET INFO FROM TORPROJECT.ORG
-torExitIPList=$(curl --silent https://check.torproject.org/torbulkexitlist?ip=1.1.1.1 | grep -v "#" | sort -u | awk '{print "\"" $1 "\","}' | tr -d "\n" | sed 's/.$//')
+torExitIPList=$(curl --silent https://check.torproject.org/torbulkexitlist?ip=1.1.1.1 | grep -v "#" | sort -un | awk '{print "\"" $1 "\","}' | tr -d "\n" | sed 's/.$//')
 
 # COMPILE OUTPUT FILE
 sed 's/\#DATE\#/'"$torLastUpdate"'/g;s/\#ARRAY-OF-TOR-IPS\#/'"$torExitIPList"'/g' $torWorkingDir$torSourceFile > $torWorkingDir$torOutputFile;


### PR DESCRIPTION
Use -u for a better sorting of IPs

-n, --numeric-sort
       compare according to string numerical value

before: 
```
217.94.252.75
219.91.110.131
222.239.250.56
23.106.122.56
23.106.34.44
23.106.58.131
```

after:
```
213.61.215.54
213.95.149.22
216.186.250.53
216.218.134.12
216.239.90.19
217.100.113.174
```